### PR TITLE
fix: added correct link for restream feature

### DIFF
--- a/docs/guides/livestream/livestream-overview.mdx
+++ b/docs/guides/livestream/livestream-overview.mdx
@@ -90,7 +90,7 @@ Dyte's ILS is supported on the following platforms:
     description="Guide to enable transcription on Dyte livesteams using Google STT"
   />
   <Card title="Livestream any video input" to="./advanced/livestream-any-rtmp" description="Guide to livestream video input from any application like OBS through Dyte" />
-  <Card title="Restream your livestream" to="/guides/capabilities/livestreaming-other-platforms" description="Guide to restream your livestream to any other streaming platform" />
+  <Card title="Restream your livestream" to="/guides/capabilities/misc/livestreaming-other-platforms" description="Guide to restream your livestream to any other streaming platform" />
 
 </CardSection>
 


### PR DESCRIPTION

## Description

Changed "https://docs.dyte.io/guides/capabilities/livestreaming-other-platforms" to "https://docs.dyte.io/guides/capabilities/misc/livestreaming-other-platforms"  Earlier link takes you to the right page if you open a new tab and to "page not found" if you click on the same tab.

## Resolved issues

Closes #1

### Before submitting the PR, please take the following into consideration
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. If you don't have an issue, please create one.
- [x]  Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
- [x] The description should clearly illustrate what problems it solves.
- [x] Ensure that the commit messages follow our guidelines.
- [x] Resolve merge conflicts (if any).
- [x] Make sure that the current branch is upto date with the `main` branch.
