### PR TITLE
fix: add example for preset_name and custom_participant_id in docs v2

### DIFF
--- a/static/api/v2.yaml
+++ b/static/api/v2.yaml
@@ -5386,6 +5386,7 @@ components:
               custom_participant_id:
                 type: string
                 description: 'A unique participant ID. You must specify a unique ID for the participant, for example, UUID, email address, and so on. '
+                example: swe-mary-4
             required:
               - preset_name
               - custom_participant_id

--- a/static/api/v2.yaml
+++ b/static/api/v2.yaml
@@ -5382,6 +5382,7 @@ components:
               preset_name:
                 type: string
                 description: Name of the preset to apply to this participant.
+                example: group_call_participant
               custom_participant_id:
                 type: string
                 description: 'A unique participant ID. You must specify a unique ID for the participant, for example, UUID, email address, and so on. '


### PR DESCRIPTION
## Description
Add example for preset_name in add_participant docs v2

Path: /api#/operations/add_participant

## Resolved issues

Closes API-257

### Before submitting the PR, please take the following into consideration
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. If you don't have an issue, please create one.
- [X] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
- [X] The description should clearly illustrate what problems it solves.
- [X] Ensure that the commit messages follow our guidelines.
- [X] Resolve merge conflicts (if any).
- [X] Make sure that the current branch is upto date with the `main` branch.
