### PR TITLE
fix(web): initClient / initMeeting ambiguity

### DIFF
--- a/docs/guides/capabilities/customize-ui/add-button-control-bar.mdx
+++ b/docs/guides/capabilities/customize-ui/add-button-control-bar.mdx
@@ -40,8 +40,10 @@ import {
 } from '@dytesdk/react-ui-kit'
 import './App.css';
 
+const [meeting, initMeeting] = useDyteClient();
+
 useEffect(() => {
-    initClient({
+    initMeeting({
       authToken: '<auth-token>',
       defaults: {
         audio: false,
@@ -50,14 +52,14 @@ useEffect(() => {
     });
  }, []);
 
-if (!client) return (<div>Loading Dyte Meeting...</div>);
+if (!meeting) return (<div>Loading Dyte Meeting...</div>);
 
 return (
   <div className="dyte-meeting">
-  <DyteProvider value={client}>
-      <DyteParticipantsAudio meeting={client} />
+  <DyteProvider value={meeting}>
+      <DyteParticipantsAudio meeting={meeting} />
       <DyteNotifications
-        meeting={client}
+        meeting={meeting}
         config={{
           config: {
             notifications: ['chat', 'participant_joined', 'participant_left'],
@@ -67,14 +69,14 @@ return (
           },
         }}
       />
-      <DyteHeader meeting={client} />
+      <DyteHeader meeting={meeting} />
       <div className="grid-container">
-        <DyteGrid meeting={client} style={{ height: '100%' }} />
+        <DyteGrid meeting={meeting} style={{ height: '100%' }} />
       </div>
       <div class="controlbar">
-        <DyteMicToggle meeting={client} />
-        <DyteCameraToggle meeting={client} />
-        <DyteSettingsToggle meeting={client} />
+        <DyteMicToggle meeting={meeting} />
+        <DyteCameraToggle meeting={meeting} />
+        <DyteSettingsToggle meeting={meeting} />
       </div>
   </DyteProvider>
   </div>
@@ -147,9 +149,9 @@ In the payload, include the peer's ID and display name.
 
 ```js
 const raiseHand = async () => {
-  await client.participants.broadcastMessage('hand-raise', {
-    id: client.self.id,
-    name: client.self.name,
+  await meeting.participants.broadcastMessage('hand-raise', {
+    id: meeting.self.id,
+    name: meeting.self.name,
   });
   setHandRaised(!handRaised);
 };
@@ -161,8 +163,8 @@ When the event is fired a notification is sent to the user using the `sendNotifi
 
 ```js
 useEffect(() => {
-  if (!client) return;
-  client.participants.on('broadcastedMessage', ({ payload }) => {
+  if (!meeting) return;
+  meeting.participants.on('broadcastedMessage', ({ payload }) => {
     const notificationObj = {
       id: new Date().getTime().toString(),
       message: `Hand Raised by ${payload.name}`,
@@ -172,9 +174,9 @@ useEffect(() => {
   });
 
   return () => {
-    client.participants.removeAllListeners('broadcastedMessage');
+    meeting.participants.removeAllListeners('broadcastedMessage');
   };
-}, [client]);
+}, [meeting]);
 ```
 
 <head>

--- a/docs/react-ui-kit/customizations/custom-iconpack.mdx
+++ b/docs/react-ui-kit/customizations/custom-iconpack.mdx
@@ -26,7 +26,7 @@ npm install @dytesdk/react-ui-kit @dytesdk/react-web-core
 2. Initialize the Dyte client using the `useDyteClient()` hook. It returns an array with two values, the meeting object and a function to initialize the meeting.
 3. Create a meeting room using the [Create Meeting API](/api#/operations/create_meeting).
 4. Generate an `authToken` using the [Add Participant API](/api#/operations/add_participant). An `authToken` is a unique token that is used to identify a user in the meeting.
-5. Initialize the meeting using the `initClient()` method exposed by `useDyteClient`.
+5. Initialize the meeting using the `initMeeting()` method exposed by `useDyteClient`.
 6. Pass the meeting object to the UI Kit.
 
 The `DyteMeeting` component generates the default UI experience. Read more about how to customize the UI [here](/react-ui-kit/basics/components-basics).
@@ -36,10 +36,10 @@ import { useDyteClient } from '@dytesdk/react-web-core';
 import { DyteMeeting } from '@dytesdk/react-ui-kit';
 
 function App() {
-  const [client, initClient] = useDyteClient();
+  const [meeting, initMeeting] = useDyteClient();
 
   useEffect(() => {
-    initClient({
+    initMeeting({
       authToken: '<auth-token>',
       defaults: {
         audio: false,
@@ -48,7 +48,7 @@ function App() {
     });
   }, []);
 
-  return <DyteMeeting meeting={client} />;
+  return <DyteMeeting meeting={meeting} />;
 }
 ```
 

--- a/docs/react-ui-kit/customizations/custom-locale.mdx
+++ b/docs/react-ui-kit/customizations/custom-locale.mdx
@@ -26,7 +26,7 @@ npm install @dytesdk/react-ui-kit @dytesdk/react-web-core
 2. Initialize the Dyte client using the `useDyteClient()` hook. It returns an array with two values, the meeting object and a function to initialize the meeting.
 3. Create a meeting room using the [Create Meeting API](/api#/operations/create_meeting).
 4. Generate an `authToken` using the [Add Participant API](/api#/operations/add_participant). An `authToken` is a unique token that is used to identify a user in the meeting.
-5. Initialize the meeting using the `initClient()` method exposed by `useDyteClient`.
+5. Initialize the meeting using the `initMeeting()` method exposed by `useDyteClient`.
 6. Pass the meeting object to the UI Kit.
 
 The `DyteMeeting` component generates the default UI experience. Read more about how to customize the UI [here](/react-ui-kit/basics/components-basics).
@@ -36,10 +36,10 @@ import { useDyteClient } from '@dytesdk/react-web-core';
 import { DyteMeeting } from '@dytesdk/react-ui-kit';
 
 function App() {
-  const [client, initClient] = useDyteClient();
+  const [meeting, initMeeting] = useDyteClient();
 
   useEffect(() => {
-    initClient({
+    initMeeting({
       authToken: '<auth-token>',
       defaults: {
         audio: false,
@@ -48,7 +48,7 @@ function App() {
     });
   }, []);
 
-  return <DyteMeeting meeting={client} />;
+  return <DyteMeeting meeting={meeting} />;
 }
 ```
 

--- a/docs/react-ui-kit/using-hooks.mdx
+++ b/docs/react-ui-kit/using-hooks.mdx
@@ -27,10 +27,10 @@ components.
 import { useDyteClient } from '@dytesdk/react-web-core';
 
 function App() {
-  const [client, initClient] = useDyteClient();
+  const [meeting, initMeeting] = useDyteClient();
 
   useEffect(() => {
-    initClient({
+    initMeeting({
       authToken: '<auth-token>',
       // set default values for user media
       defaults: {
@@ -41,7 +41,7 @@ function App() {
   }, []);
 
   return (
-    <DyteProvider value={client}>
+    <DyteProvider value={meeting}>
       <Meeting />
     </DyteProvider>
   );

--- a/docs/rn-ui-kit/using-hooks.mdx
+++ b/docs/rn-ui-kit/using-hooks.mdx
@@ -27,7 +27,7 @@ components.
 import { useDyteClient } from '@dytesdk/react-native-core';
 
 function App() {
-  const [client, initClient] = useDyteClient();
+  const [meeting, initMeeting] = useDyteClient();
 
   useEffect(() => {
     const init = async () => {
@@ -43,7 +43,7 @@ function App() {
   }, []);
 
   return (
-    <DyteProvider value={client}>
+    <DyteProvider value={meeting}>
       {/* Render your component */}
       <MyComponent />
     </DyteProvider>

--- a/src/theme/Playground/index.jsx
+++ b/src/theme/Playground/index.jsx
@@ -82,11 +82,11 @@ export default function Playground({ children, transformCode, ...props }) {
 
   const prismTheme = usePrismTheme();
 
-  const [client, initClient] = useDyteClient();
+  const [meeting, initMeeting] = useDyteClient();
 
   // TODO: Uncomment following block of code after adding mock web-core package
   useEffect(() => {
-    initClient({
+    initMeeting({
       roomName: 'qplrfc-uuujcj',
       authToken:
         'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjdkYzU0MGRjLWQ5MjUtNDVjMi1hZTFiLWM2NDc2YTUwNmM2NyIsImxvZ2dlZEluIjp0cnVlLCJpYXQiOjE2NjU2NDcxNjksImV4cCI6MTY3NDI4NzE2OX0.hJvo1PV1_jaxwiQbT8ft7Yi4lhIPgAsuEJHqohHYC_2XNef7kA4NhrYLvwrrxOo3AKh9_XTjnj_bsgzIDh35RRggawJniEjuE83ju2xhMXMVaa7TNDje2BsH5-VnFJ4y5hOwxGphrP5iHY_U4k_0qOQcEfVEJMymJvx0gq_Ueds',
@@ -94,31 +94,31 @@ export default function Playground({ children, transformCode, ...props }) {
         audio: false,
         video: false,
       },
-    }).then((meeting) => {
-      Object.defineProperty(meeting.self.permissions, 'produceAudio', {
+    }).then((m) => {
+      Object.defineProperty(m.self.permissions, 'produceAudio', {
         value: 'ALLOWED',
       });
-      Object.defineProperty(meeting.self.permissions.produceVideo, 'allow', {
+      Object.defineProperty(m.self.permissions.produceVideo, 'allow', {
         value: 'ALLOWED',
       });
-      Object.defineProperty(meeting, 'connectedMeetings', {
+      Object.defineProperty(m, 'connectedMeetings', {
         value: {
           supportsConnectedMeetings: false,
         },
       });
-      meeting.meta.meetingStartedTimestamp = new Date();
-      meeting.participants.mockAddParticipants(5, 5);
-      meeting.recording.recordingState = 'RECORDING';
+      m.meta.meetingStartedTimestamp = new Date();
+      m.participants.mockAddParticipants(5, 5);
+      m.recording.recordingState = 'RECORDING';
     });
   }, []);
 
   if (typeof window !== 'undefined') {
-    window.meeting = client || {};
+    window.meeting = meeting || {};
   }
 
   return (
     <div className={styles.playgroundContainer}>
-      <DyteProvider value={client}>
+      <DyteProvider value={meeting}>
         {/* @ts-expect-error: type incompatibility with refs */}
         <LiveProvider
           code={children.replace(/\n$/, '')}

--- a/static/release-notes/react-web-core.json
+++ b/static/release-notes/react-web-core.json
@@ -149,7 +149,7 @@
         "version": "1.14.0",
         "createdAt": 1686303420,
         "fixes": [
-            "Added execution locks around `initClient` method to prevent accidental double initialisation method calls",
+            "Added execution locks around `initMeeting` method to prevent accidental double initialisation method calls",
             "Handled multiple edge cases around media capture and its retention"
         ],
         "features": [


### PR DESCRIPTION
Rename all instances of `initClient ` to `initMeeting`