### PR TITLE
docs: Update semis to commas in JS code snippet

### DIFF
--- a/docs/angular-ui-kit/design-system.mdx
+++ b/docs/angular-ui-kit/design-system.mdx
@@ -70,9 +70,9 @@ You can edit this value in two ways with the provideDyteDesignSystem utility.
 
 ```js
 const designTokens = {
-  fontFamily: 'Custom Font';
+  fontFamily: 'Custom Font',
   // or
-  googleFont: 'A Google Font';
+  googleFont: 'A Google Font',
 }
 ```
 


### PR DESCRIPTION
## Description

Noticed a tiny issue in the docs where a JS object was separating values with `;` instead of `,`.