### PR TITLE
New section added.

### DIFF
--- a/docs/guides/migration/twilio/concepts-twilio-vs-dyte.mdx
+++ b/docs/guides/migration/twilio/concepts-twilio-vs-dyte.mdx
@@ -7,6 +7,14 @@ description: >-
   guide for a comprehensive comparison and migration strategy.
 ---
 
+:::tip
+Affected by the Twilio Sunset? Migrate to Dyte and get more than just feature parity with interactive plugins, UI Kit, advanced analytics and much more for your use-case. Twilio Video are eligible to receive credits upto $30,000.
+
+<div class="cta_wrapper"> <a href="https://dyte.io/twilio-video-competitor?docs=true" class="cta_button"> Claim credits upto $30,000 </a>
+ </div>
+ <p class="is_invisible">invisible text here</p>
+:::
+
 This topic guides you through the standard practices utilized in [Twilio Video API](https://www.twilio.com/docs/video) and illustrates how they correspond with Dyte's API. The main purpose of this tutorial is to support you in migrating an existing application from Twilio to Dyte's video and audio APIs.
 
 ## Overview

--- a/docs/guides/migration/twilio/feature-comparison.mdx
+++ b/docs/guides/migration/twilio/feature-comparison.mdx
@@ -42,6 +42,17 @@ sidebar_position: 5
 
 <br />
 
+
+:::tip
+Download a detailed benchmarking report to compare features, technical specs and pricing to choose the most suitable Twilio Video replacement.
+
+
+<div class="cta_wrapper"> <a href="https://dyte.io/twilio-video-competitor?docs=true" class="cta_button"> Download now </a>
+ </div>
+ 
+ <p class="is_invisible">invisible text here</p>
+:::
+
 1. **PSTN** 🔵 : Can integrate with third-party SIP to provide telephony support.
 
 2. **Callkit (iOS)** 🟠 : Customers can add it at their end, sample code is available.

--- a/docs/react-ui-kit/introduction.mdx
+++ b/docs/react-ui-kit/introduction.mdx
@@ -51,3 +51,4 @@ Uses a layered design structure, allowing you to start with one prebuilt compone
 <head>
   <title>React UI Kit Introduction</title>
 </head>
+

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1249,3 +1249,27 @@ html[data-theme='dark'] .video_sidebar_header > div > a::before {
 img {
   @apply rounded-xl;
 }
+
+.cta_button{
+  padding: 16px 32px;
+  background-color: #2160fd;
+  color: white;
+  border-radius: 8px;
+  text-decoration: none;
+  
+}
+
+.cta_button:hover{
+  color: white;
+  text-decoration: none;
+}
+
+.cta_wrapper{
+  margin-top: 40px;
+  
+}
+
+.is_invisible{
+  color: white;
+  opacity: 0%;
+}


### PR DESCRIPTION
Added new section on/guides/migration/twilio/concepts-twilio-vs-dyte page
<img width="863" alt="Screenshot 2024-03-04 at 2 07 39 PM" src="https://github.com/dyte-io/docs/assets/153725458/72bf8241-6ecb-4315-9b87-f3490df71553">

and on /guides/migration/twilio/feature-comparison page

<img width="933" alt="Screenshot 2024-03-04 at 2 08 19 PM" src="https://github.com/dyte-io/docs/assets/153725458/53d04e95-f304-4bd4-bbce-a928d00b95d3">
