### PR TITLE
ifix: update ios core sample app link

### DIFF
--- a/docs/ios-core/quickstart.mdx
+++ b/docs/ios-core/quickstart.mdx
@@ -18,9 +18,9 @@ This quickstart shows how to use Dyte's iOS Core SDK to add live video and audio
 to your iOS applications.
 
 For getting started quickly, you can use our
-[sample code](https://github.com/dyte-io/mobile-core-sample-ios). You can clone
+[sample code](https://github.com/dyte-io/ios-samples/tree/main/iOS-core). You can clone
 and run a sample application from the
-[iOS Core SDK GitHub repository](https://github.com/dyte-io/mobile-core-sample-ios).
+[iOS Core SDK GitHub repository](https://github.com/dyte-io/ios-samples/tree/main/iOS-core).
 
 ## Objective
 


### PR DESCRIPTION
fixed broken link on quick-start for core now points to ios-samples