### PR TITLE
docs: refactor flutter_core docs

### DIFF
--- a/docs/flutter-core/chat/introduction.mdx
+++ b/docs/flutter-core/chat/introduction.mdx
@@ -26,11 +26,12 @@ The `DyteChatMessage` class has the following properties:
 - `displayName` : Display name of the sender.
 - `read` : Boolean whether the message is read or not.
 - `pluginId` : Plugin ID of the message.
+- `time` : Time at which the message was sent. It returns a `String` in milliseconds since epoch format.
 - `type` : `DyteMessageType` for type of message being sent (whether
   `DyteMessageType.text`, `DyteMessageType.image` or `DyteMessageType.file`).
 
 There are 3 message classes that extends `DyteChatMessage`, and each has some
-extra parameter apart from `DyteChatMessage` ones:
+extra property in addition to `DyteChatMessage` properties:
 
 - `DyteTextMessage`
 - `DyteImageMessage`
@@ -42,14 +43,13 @@ extra parameter apart from `DyteChatMessage` ones:
 
 #### DyteImageMessage:
 
-- `link`: URL to the bucket where the image is stored.
-- `fileUri`: Local path URL of image selected.
-- `fileName`: Name of image selected.
+- `link`: URL of the image sent.
 
 #### DyteFileMessage:
 
 - `name`: Name of the file to be sent.
-- `fileUri`: Local path URL of the file selected.
+- `link`: URL of the file sent.
+- `size`: Size of the file in bytes.
 
 <head>
   <title>Flutter Core Introducing chat</title>

--- a/docs/flutter-core/chat/sending-a-chat-message.mdx
+++ b/docs/flutter-core/chat/sending-a-chat-message.mdx
@@ -17,7 +17,7 @@ a message of each type.
 
 ## Send a text message
 
-To send a text message, the `dyteClient.chat.sendTextMessage()` method can be
+To send a text message, the `dyteClient.chat.sendTextMessage(message)` method can be
 used. It take a string `message` as an argument and sends it to the room.
 
 ```dart

--- a/docs/flutter-core/host-actions.mdx
+++ b/docs/flutter-core/host-actions.mdx
@@ -1,0 +1,198 @@
+---
+title: Host Actions & Permissions
+description: >-
+  Understand the host actions you can perform as per preset permissions set in Developer Portal & integration in Dyte's Flutter SDK.
+sidebar_position: 13
+tags:
+  - flutter-core
+  - permissions
+  - host actions
+---
+
+# Host Actions & Permissions
+
+Based on your peer preset permissions you can perform certain host actions in Dyte's Flutter SDK. As you follow through this page, you'll know what the host actions are and how to implement it based on permissions.
+
+## Permissions
+
+Permissions are set in the Developer Portal. Based on the permissions set, you can perform certain host actions. To access permissions, use `dyteClient.permissions` method. The permissions are as follows:
+
+### Media Permissions
+
+Media permissions (audio, video and screenshare) can be accessed using `dyteClient.permissions.media`. You can get audio, video and screenshare permissions. Audio and screenshare permissions are of `DyteMediaPermission` type & video permissions are of `DyteVideoPermissions` type.
+
+`DyteMediaPermission` is a enum & can have 3 values:
+
+- `DyteMediaPermission.allowed` : If the user is allowed to access the media.
+- `DyteMediaPermission.canRequest` : If the user can request access to the media. Ex: If a user is off stage but can request to come on stage in case of webinar.
+- `DyteMediaPermission.notAllowed` : If the user is not allowed to access the media.
+
+`DyteVideoPermissions` have 3 properties:
+
+- `permission`: It is of `DyteMediaPermission` type & stores the video permission.
+- `frameRate` : It is of type `int` & stores the frame rate of the video.
+- `quality` : It is of type `string` and stores the quality of the video.
+
+```dart
+
+// To get audio permission
+final DyteMediaPermission audioPermission = dyteClient.permissions.media.audio;
+
+// To get video details
+final DyteVideoPermissions videoPermission = dyteClient.permissions.media.video;
+
+// To get screenshare permission
+final DyteMediaPermission screensharePermission = dyteClient.permissions.media.screenshare;
+```
+
+### Waiting Room Permissions
+
+Waiting room permissions are of type `WaitingRoomPermissions` contains 2 properties:
+
+- `canAcceptRequests`: It is of type `bool` & tells if the user can accept/reject waiting requests of participants present in waiting room.
+- `type`: It is of enum type `WaitingRoomType` and is useful to know where client can directly enter meeting room or need permission from host.
+
+`WaitingRoomType` can have 4 values:
+
+- `WaitingRoomType.skip` : If the user can directly enter the meeting room.
+- `WaitingRoomType.onAccept` : If the user needs permission from host to enter the meeting room.
+- `WaitingRoomType.skipOnAccept` : If the user needs permission from host just the first time while trying to join meeting room.
+- `WaitingRoomType.skipOnPriviligedUserEntry` : If the user can enter once there's a privileged user is present in the room.
+
+```dart
+final WaitingRoomPermissions waitingRoomPermissions = dyteClient.permissions.waitingRoom;
+```
+
+### Chat Permissions
+
+Chat permissions are of type `ChatPermissions` contains 2 properties:
+
+- `canSendText`: It is of type `bool` & tells if the user can send messages in the chat.
+- `canSendFiles`: It is of type `bool` & tells if the user can send images/files in the chat.
+
+```dart
+final ChatPermissions chatPermissions = dyteClient.permissions.chat;
+```
+
+### Host Permissions
+
+Host permissions are of type `HostPermissions` contains 5 properties:
+
+- `canMuteAudio`: It is of type `bool` & tells if the user can mute audio of other participants in the room.
+- `canDisableVideo`: It is of type `bool` & tells if the user can disable other participant's video.
+- `canKickParticipant`: It is of type `bool` & tells if the user can kick other participants from the room.
+- `canPinParticipant`: It is of type `bool` & tells if the user can pin other participants in the room.
+- `canTriggerRecording`: It is of type `bool` & tells if the user can trigger recording in the room.
+
+```dart
+final HostPermissions hostPermissions = dyteClient.permissions.host;
+```
+
+### Poll Permissions
+
+Poll permissions are of type `PollPermissions` contains 3 properties:
+
+- `canCreate`: It is of type `bool` & tells if the user can create polls in the meeting room.
+- `canVote`: It is of type `bool` & tells if the user can vote in the polls.
+- `canView`: It is of type `bool` & tells if the user can view the polls.
+
+```dart
+final PollPermissions pollPermissions = dyteClient.permissions.poll;
+```
+
+### Plugin Permissions
+
+Plugin permissions are of type `PluginPermissions` contains 2 properties:
+
+- `canLaunch`: It is of type `bool` & tells if the user can launch plugins in the meeting room.
+- `canClose`: It is of type `bool` & tells if the user can close plugins in the meeting room.
+
+```dart
+final PluginPermissions pluginPermissions = dyteClient.permissions.plugin;
+```
+
+### Livestream Permissions
+
+Livestream permissions are of type `LivestreamPermissions` contains the following property:
+
+- `canLivestream`: It is of type `bool` & tells if the user can start/stop livestreaming.
+
+```dart
+final LivestreamPermissions livestreamPermissions = dyteClient.permissions.livestream;
+```
+
+### Miscellaneous Permissions
+
+Miscellaneous permissions are of type `MiscellaneousPermissions` with following property:
+
+- `canEditDisplayName`: It is of type `bool` & tells if the user can edit their display name.
+
+## Host Actions
+
+A peer can execute following actions if their preset allows it. To access preset permissions, see the permissions section [above](#permissions):
+
+### Pin/Unpin participant
+
+You can pin & unpin a participant in a meeting room. Use `pinParticipant(participant)` and `unpinParticipant()` method to pin & unpin the `participant` respectively. The `participant` is of `DyteMeetingParticipant`type.
+
+```dart
+
+// Pin the `participant`
+dyteClient.hostActions.pinParticipant(participant);
+
+// Unpin pinned participant
+dyteClient.hostActions.unpinParticipant();
+```
+
+### Kick participant(s)
+
+You can kick a participant or kick all participants from a meeting using `kickParticipant(participant)` and `kickAll()` method respectively. The `participant` is of `DyteMeetingParticipant` type.
+
+```dart
+
+// Kick the `participant`
+dyteClient.hostActions.kickParticipant(participant);
+
+// Kick all participants
+dyteClient.hostActions.kickAll();
+```
+
+### Accept/Reject waitlisted request
+
+You can accept or reject a waitlisted request using `acceptWaitlistedParticipant(participant)` and `rejectWaitlistedParticipant(participant)` method respectively. The `participant` is of `DyteMeetingParticipant` type.
+
+```dart
+
+// Accept the waitlisted `waitlistedParticipant`
+dyteClient.hostActions.acceptWaitlistedParticipant(waitlistedParticipant);
+
+// Reject the waitlisted `waitlistedParticipant`
+dyteClient.hostActions.rejectWaitlistedParticipant(waitlistedParticipant);
+```
+
+### Mute participant(s) audio
+
+You can mute a participant's audio or mute all participants' audio using `disableParticipantAudio(participant)` and `muteAllAudios()` method respectively. The `participant` is of `DyteMeetingParticipant` type.
+
+```dart
+
+// Mute the `participant` audio
+dyteClient.hostActions.disableParticipantAudio(participant);
+
+// Mute all participants' audio
+dyteClient.hostActions.muteAllAudios();
+
+```
+
+### Disable participant(s) video
+
+You can disable a participant's video or disable all participants' video using `disableParticipantVideo(participant)` and `disableAllVideos()` method respectively. The `participant` is of `DyteMeetingParticipant` type.
+
+```dart
+
+// Disable the `participant` video
+dyteClient.hostActions.disableParticipantVideo(participant);
+
+// Disable all participants' video
+dyteClient.hostActions.disableAllVideos();
+```

--- a/docs/flutter-core/local-user/introduction.mdx
+++ b/docs/flutter-core/local-user/introduction.mdx
@@ -32,6 +32,7 @@ Here is a list of properties that local user provides:
   - `hidden`: if the participant is hidden
 - `audioEnabled`: Boolean value indicating if the audio currently enabled.
 - `videoEnabled`: Boolean value indicating if the video currently enabled.
+- `stageStatus` : Stage status of the local participant.
 
 Local user properties can be fetched via `localUser` getter on the `dyteClient`.
 
@@ -54,7 +55,7 @@ final meetingInfo = DyteMeetingInfoV2(
 );
 ```
 
-## Turn audio/video tracks after initializing the client
+## Turn on audio/video tracks after initializing the client
 
 If audio and video tracks are disabled during the `DyteMobileClient`
 initialization process. You can setup the audio and video tracks by simply
@@ -111,16 +112,6 @@ final isVideoEnabled = dyteClient.localUser.videoEnabled;
 dyteClient.localUser.switchCamera();
 ```
 
-## Broadcast Message to all participants
-
-```dart
-// payload is a Map<String, dynamic>
-const payload = {
-  "message": "Hello World",
-};
-dyteClient.broadcastMessage("type", payload);
-```
-
 ## Enable / Disable Screen share
 
 ```dart
@@ -130,7 +121,6 @@ dyteClient.localUser.enableScreenshare();
 // Disable Screenshare
 dyteClient.localUser.disableScreenshare();
 ```
-
 
 <head>
   <title>Flutter Core Introduction</title>

--- a/docs/flutter-core/participants/events.mdx
+++ b/docs/flutter-core/participants/events.mdx
@@ -73,17 +73,6 @@ void onVideoUpdate({
 ...
 ```
 
-## Video view
-
-To access the video view of a participant, create an object of the `VideoView` class.
-
-```dart
-// To show the video of a participant
-final videoView = VideoView(meetingParticipant: participant);
-// To get video view for a local user
-final selfVideoView = VideoView(isSelfTrue: true);
-```
-
 ## Audio update
 
 Triggers an event when a participant starts or stops the audio.

--- a/docs/flutter-core/participants/introduction.mdx
+++ b/docs/flutter-core/participants/introduction.mdx
@@ -59,6 +59,17 @@ is returned with `onGridUpdated` event. It contains the following properties:
 - `isNextPagePossible`: bool, if the next page of participants is available.
 - `isPreviousPagePossible`: bool, if previous page of participants is available.
 
+## Video view
+
+To access the video view of a participant, create an object of the `VideoView` class.
+
+```dart
+// To show the video of a participant
+final videoView = VideoView(meetingParticipant: participant);
+// To get video view for a local user
+final selfVideoView = VideoView(isSelfTrue: true);
+```
+
 ## Move between pages in paginated mode
 
 The `setPage(int pageNumber)` method allows you to switch between pages of
@@ -71,6 +82,16 @@ _Note: Indexing of page starts from 0_
 dyteClient.setPage(1);
 ```
 
+## Broadcast Message to all participants
+
+```dart
+// payload is a Map<String, dynamic>
+const payload = {
+  "message": "Hello World",
+};
+dyteClient.broadcastMessage("type", payload);
+```
+
 ## Video update for all participants
 
 Triggered when any participant of the meeting enable/disable it's video. It also passes the participant details who has updated it's video status.
@@ -80,7 +101,7 @@ class ParticipantNotifier implements DyteParticipantEventsListener{
 
   ...
   @override
-  void videoUpdate(
+  void onVideoUpdate(
     bool videoEnabled,
     DyteJoinedMeetingParticipant participant,
   ) {
@@ -102,7 +123,7 @@ class ParticipantNotifier implements DyteParticipantEventsListener{
 
   ...
   @override
-  void audioUpdate(
+  void onAudioUpdate(
     bool audioEnabled,
     DyteJoinedMeetingParticipant participant,
   ) {

--- a/docs/flutter-core/participants/participant-object.mdx
+++ b/docs/flutter-core/participants/participant-object.mdx
@@ -1,5 +1,5 @@
 ---
-title: The participant object
+title: Participant object
 description: >-
   Understand the participant object and its integration in Flutter. Follow
   Dyte's documentation for effective implementation in your app.

--- a/docs/flutter-core/polls/creating-a-poll.mdx
+++ b/docs/flutter-core/polls/creating-a-poll.mdx
@@ -1,5 +1,5 @@
 ---
-title: Creating a poll
+title: Create & Vote a poll
 description: >-
   Learn how to create polls in Flutter using Dyte's features. Follow our
   documentation for seamless integration and effective poll creation.
@@ -34,7 +34,29 @@ dyteClient.polls.create(
 );
 ```
 
+# Voting on a poll
+
+The `dyteClient.polls.vote()` method can be used to register a vote on a poll.
+It accepts the following params.
+
+| Param       | Type            | Default Value | Required | Description                                                |
+| ----------- | --------------- | ------------- | -------- | ---------------------------------------------------------- |
+| pollMessage | DytePollMessage | -             | yes      | Contains all the poll properties (question, options, etc.) |
+| pollOption  | DytePollOption  | yes           | yes      | Option on which the user voted                             |
+
+The following snippet votes for the 1st option on the 1st poll created in the
+meeting.
+
+```dart
+final poll = dyteClient.polls.polls[0];
+final selectedPollOption = poll.options[0];
+dyteClient.polls.vote(poll, selectedPollOption);
+```
+
 <head>
-  <title>Flutter Core Creating a poll</title>
-  <meta name="description" content="Learn how to create polls in Flutter using Dyte's features. Follow our documentation for seamless integration and effective poll creation."/>
+  <title>Flutter Core creating/voting a poll</title>
+  <meta
+    name="description"
+    content="Learn how to create and vote on polls in Flutter using Dyte's features. Follow our documentation for seamless integration and effective poll creation."
+  />
 </head>

--- a/docs/flutter-core/polls/introduction.mdx
+++ b/docs/flutter-core/polls/introduction.mdx
@@ -41,40 +41,6 @@ The `DytePollMessage` class has the following properties:
 - `id` : ID of the voter.
 - `name` : Name of the voter.
 
-## Listening to new polls in a meeting
-
-To be able to receive new poll messages you need to implement a method
-`onPollUpdates()` method from callback `DytePollEventsListener`:
-
-To get poll updates, listen to `onPollUpdates()` callback:
-
-```dart
-
-class PollEventsListeners extends DytePollEventsListener {
-
-  ...
-
-  @override
-  void onPollUpdates(List<DytePollMessage> polls) {
-    /// code to handle polls
-  }
-
-  @override
-  void onNewPoll(DytePollMessage poll) {
-    /// code to handle new poll
-  }
-
-  ...
-}
-
-```
-
-You can subscribe to this events by `addPollEventsListener` method:
-
-```dart
-dyteClient.addPollEventsListener(PollEventsListeners());
-```
-
 <head>
   <title>Flutter Core Introduction</title>
   <meta name="description" content="Get started with Dyte's polling features in Flutter. Follow our documentation for an introduction to polling capabilities in your app."/>

--- a/docs/flutter-core/polls/receiving-polls.mdx
+++ b/docs/flutter-core/polls/receiving-polls.mdx
@@ -1,0 +1,47 @@
+---
+title: Receiving polls
+description: >-
+  Understand how users can vote on polls in Flutter with Dyte's features. Follow
+  our documentation for effective implementation in your app.
+sidebar_position: 3
+tags:
+  - flutter-core
+  - polls
+  - votes
+---
+
+To be able to receive new poll messages you need to implement a method
+`onPollUpdates()` method from callback `DytePollEventsListener`:
+
+To get poll updates, listen to `onPollUpdates()` callback:
+
+```dart
+
+class PollEventsListeners extends DytePollEventsListener {
+
+  ...
+
+  @override
+  void onPollUpdates(List<DytePollMessage> polls) {
+    /// code to handle polls
+  }
+
+  @override
+  void onNewPoll(DytePollMessage poll) {
+    /// code to handle new poll
+  }
+
+  ...
+}
+
+```
+
+You can subscribe to this events by `addPollEventsListener` method:
+
+```dart
+dyteClient.addPollEventsListener(PollEventsListeners());
+```
+
+<head>
+  <title>Flutter Core listening to polls</title>
+</head>

--- a/docs/flutter-core/room-metadata.mdx
+++ b/docs/flutter-core/room-metadata.mdx
@@ -14,7 +14,7 @@ tags:
 All metadata related to a meeting is stored in `meeting.meta`. This includes:
 
 - `roomName`: The name of the room the current participant is connected to.
-- `roomType`: Indicates the meeting is a group-call or a webinar.
+- `roomType`: Indicates the meeting is a group-call, webinar or livestream.
 - `meetingTitle`: The title of the meeting.
 - `meetingStartedTimestamp`: The timestamp when the meeting started.
 


### PR DESCRIPTION
- Introduce a dedicated page for accessing permissions and host actions.
- Shift `broadcastMessage` API from localUser to participants section.
- Fix chat pages.
- Clubbed create & vote poll page.
- Separated poll updates page.
- Minor typo fixes.