### PR TITLE
fix(guides-recording): update the Stop Recording API url

### DIFF
--- a/docs/guides/capabilities/recording/stop-recording.mdx
+++ b/docs/guides/capabilities/recording/stop-recording.mdx
@@ -13,13 +13,13 @@ Dyte recordings can be stopped in any of the following ways:
    wait time can be customized by contacting Dyte's support team to configure a
    custom value for your organization.
 2. **Automatic Stop (maxSeconds elapsed)**: A recording will automatically stop
-   regardless of if there are participants or not in the meeting if the
-   recording has been going on for a duration more than the `max_seconds`
-   parameter passed to the recording while starting it. If this parameter is not
-   passed, it has a default value of 24 hours (86400 seconds).
+   when it reaches the duration specified by the `max_seconds` parameter passed
+   while starting the recording, regardless of whether participants are present
+   in the meeting. If this parameter is not passed, it defaults to 24 hours
+   (86400 seconds).
 3. **Using Stop Recording API**: A recording can also be stopped by passing the
-   recording ID to our [Stop Recording](/api/?v=v2#/operations/stop_recording)
-   APIs.
+   recording ID & `stop` action to our [Pause/Resume/Stop recording](/api/?v=v2#/operations/pause_resume_stop_recording)
+   API.
 
 When a recording is stopped, it transitions to the `UPLOADING` state and then to the `UPLOADED` state after it has been transferred to Dyte's storage and any external storage that has been set up.
 


### PR DESCRIPTION
## Description

Updates the Stop Recording API url to "https://docs.dyte.io/api?v=v2#/operations/pause_resume_stop_recording".
Also improves the the "Automatic Stop (maxSeconds elapsed)" point.