### PR TITLE
Layout fix

### DIFF
--- a/src/components/homepage/ResourcesSection.tsx
+++ b/src/components/homepage/ResourcesSection.tsx
@@ -128,7 +128,7 @@ export default function ResourcesSection() {
   };
 
   return (
-    <section className="no-underline-links my-20 px-6">
+    <section className="no-underline-links my-20 px-6 ">
       <div className="mx-auto max-w-5xl">
         <div className="flex items-center justify-between">
           <div>
@@ -177,7 +177,7 @@ export default function ResourcesSection() {
         </div>
 
         <div className="relative flex flex-col">
-          <div className="no-underline-links grid grid-cols-3 gap-6 md:grid-cols-2 lg:grid-cols-3">
+          <div className="no-underline-links grid grid-cols-3 gap-6 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
             {currentResources.map((resource, idx) => {
               return <Resource {...resource} key={idx} />;
             })}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1250,9 +1250,12 @@ img {
   @apply rounded-xl;
 }
 
+<<<<<<< Updated upstream
 h2.anchor > code {
   @apply mx-2;
 }
+=======
+>>>>>>> Stashed changes
 .cta_button {
   padding: 16px 32px;
   background-color: #2160fd;
@@ -1275,6 +1278,7 @@ h2.anchor > code {
   padding-top: 16px;
   padding-bottom: 16px;
 }
+<<<<<<< Updated upstream
 
 .code-viewer > .sp-code-editor > pre {
   padding: 0px;
@@ -1342,3 +1346,5 @@ h2.anchor > code {
 .custom-list .container ul {
   @apply pl-4;
 }
+=======
+>>>>>>> Stashed changes

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1250,12 +1250,9 @@ img {
   @apply rounded-xl;
 }
 
-<<<<<<< Updated upstream
 h2.anchor > code {
   @apply mx-2;
 }
-=======
->>>>>>> Stashed changes
 .cta_button {
   padding: 16px 32px;
   background-color: #2160fd;
@@ -1278,7 +1275,6 @@ h2.anchor > code {
   padding-top: 16px;
   padding-bottom: 16px;
 }
-<<<<<<< Updated upstream
 
 .code-viewer > .sp-code-editor > pre {
   padding: 0px;
@@ -1330,7 +1326,7 @@ h2.anchor > code {
   list-style-type: none !important;
 }
 
-.custom-list .container li p:first-child  {
+.custom-list .container li p:first-child {
   @apply flex items-center gap-2;
 }
 .custom-list .container li p:nth-child(2) {
@@ -1338,13 +1334,10 @@ h2.anchor > code {
 }
 
 .custom-list .container li p:first-child::before {
-  content: "";
-  @apply h-3 w-3 rounded-full bg-gray-300 group-hover:bg-gray-400 block float-left;
-
+  content: '';
+  @apply float-left block h-3 w-3 rounded-full bg-gray-300 group-hover:bg-gray-400;
 }
 
 .custom-list .container ul {
   @apply pl-4;
 }
-=======
->>>>>>> Stashed changes


### PR DESCRIPTION
**Resolved this layout bug in mobile breakpoint.**

<img width="343" alt="Screenshot 2024-04-01 at 12 55 05 PM" src="https://github.com/dyte-io/docs/assets/153725458/b82c647a-79be-41dd-9394-156bb95c546b">

changed to 👇

<img width="349" alt="Screenshot 2024-04-01 at 12 55 53 PM" src="https://github.com/dyte-io/docs/assets/153725458/c341b3a2-64c4-47b6-8195-92802c1b487e">
