### PR TITLE
docs(dyteself-dyteselfmedia): added linking between dyteself and dyteselfmedia

### DIFF
--- a/docs/react-web-core/reference/DyteSelf.md
+++ b/docs/react-web-core/reference/DyteSelf.md
@@ -11,6 +11,20 @@ The DyteSelf module represents the current user, and allows to modify the state
 of the user in the meeting. The audio and video streams of the user can be retrieved from
 this module.
 
+:::tip Note
+DyteSelf extends [DyteSelfMedia](./DyteSelfMedia) therefore all the methods & variables exposed by DyteSelfMedia are also available on DyteSelf.
+
+Few examples:
+```tsx
+meeting.self.rawAudioTrack;
+meeting.self.rawVideoTrack;
+meeting.self.audioEnabled;
+meeting.self.videoEnabled;
+await meeting.self.getAudioDevices();
+await meeting.self.getVideoDevices();
+```
+:::
+
 
 * [DyteSelf](#module_DyteSelf)
     * [.roomState](#module_DyteSelf+roomState)

--- a/docs/web-core/reference/DyteSelf.md
+++ b/docs/web-core/reference/DyteSelf.md
@@ -11,6 +11,19 @@ The DyteSelf module represents the current user, and allows to modify the state
 of the user in the meeting. The audio and video streams of the user can be retrieved from
 this module.
 
+:::tip Note
+DyteSelf extends [DyteSelfMedia](./DyteSelfMedia) therefore all the methods & variables exposed by DyteSelfMedia are also available on DyteSelf.
+
+Few examples:
+```tsx
+meeting.self.rawAudioTrack;
+meeting.self.rawVideoTrack;
+meeting.self.audioEnabled;
+meeting.self.videoEnabled;
+await meeting.self.getAudioDevices();
+await meeting.self.getVideoDevices();
+```
+:::
 
 * [DyteSelf](#module_DyteSelf)
     * [.roomState](#module_DyteSelf+roomState)


### PR DESCRIPTION
## Description

Clients were unable to figure out the methods to retrieve audio/video/screenshare tracks from self. Since DyteSelfMedia is a different reference, added a note to DyteSelf to highlight the connection.

<img width="788" alt="image" src="https://github.com/dyte-io/docs/assets/99713383/f75757e6-151e-4d32-b89f-36c457bb3501">

### Before submitting the PR, please take the following into consideration
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. If you don't have an issue, please create one.
- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
- [x] The description should clearly illustrate what problems it solves.
- [x] Ensure that the commit messages follow our guidelines.
- [x] Resolve merge conflicts (if any).
- [x] Make sure that the current branch is upto date with the `main` branch.
