### PR TITLE
fix(android-core): add hyperlink to waitlisted-participants page in Pre-call Waiting Room

### DIFF
--- a/docs/android-core/pre-call/4-waiting-room.mdx
+++ b/docs/android-core/pre-call/4-waiting-room.mdx
@@ -52,4 +52,4 @@ meeting.addSelfEventsListener(object : DyteSelfEventsListener {
 })
 ```
 
-Host can use [these methods to accept/reject participants](/android-core/participants#waiting-room-methods).
+Host can use [these methods to accept/reject participants](/android-core/participants/waitlisted-participants).


### PR DESCRIPTION
## Description
Use hyperlink to Waitlisted Participant page in Pre-call section's Waiting Room page.
