### PR TITLE
fix: remove stray table syntax

### DIFF
--- a/docs/android/quickstart.mdx
+++ b/docs/android/quickstart.mdx
@@ -74,11 +74,11 @@ Configure the following properties in the `DyteMeetingInfoV2` class. You must pa
 obtained from the [Add Participant](/api/?v=v2#/operations/add_participant) API.
 
 | Name          | Description                                                                                                                    |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------ | --- |
-| `authToken`   | Authentication token generated using the [Add Participant API](/api/?v=v2#/operations/add_participant) after meeting creation. |     |
-| `enableAudio` | Set whether to join the meeting with your Mic ON (`true`) or OFF (`false`).                                                    |     |
-| `enableVideo` | Set whether to join the meeting with your Camera ON (`true`) or OFF (`false`).                                                 |     |
-| `baseUrl`     | Base URL of the Dyte environment you have created the meeting on.                                                              |     |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `authToken`   | Authentication token generated using the [Add Participant API](/api/?v=v2#/operations/add_participant) after meeting creation. |
+| `enableAudio` | Set whether to join the meeting with your Mic ON (`true`) or OFF (`false`).                                                    |
+| `enableVideo` | Set whether to join the meeting with your Camera ON (`true`) or OFF (`false`).                                                 |
+| `baseUrl`     | Base URL of the Dyte environment you have created the meeting on.                                                              |
 
 <Tabs groupId="dyte-android-uikit">
   <TabItem value="kotlin" label="Kotlin" default>

--- a/docs/ios/quickstart.mdx
+++ b/docs/ios/quickstart.mdx
@@ -100,11 +100,11 @@ Configure the following properties in the `DyteMeetingInfoV2` class. You must pa
 obtained from the [Add Participant](/api/?v=v2#/operations/add_participant) API.
 
 | Name          | Description                                                                                                                    |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------ | --- |
-| `authToken`   | Authentication token generated using the [Add Participant API](/api/?v=v2#/operations/add_participant) after meeting creation. |     |
-| `enableAudio` | Set whether to join the meeting with your Mic ON (`true`) or OFF (`false`).                                                    |     |
-| `enableVideo` | Set whether to join the meeting with your Camera ON (`true`) or OFF (`false`).                                                 |     |
-| `baseUrl`     | Base URL of the Dyte environment you have created the meeting on.                                                              |     |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `authToken`   | Authentication token generated using the [Add Participant API](/api/?v=v2#/operations/add_participant) after meeting creation. |
+| `enableAudio` | Set whether to join the meeting with your Mic ON (`true`) or OFF (`false`).                                                    |
+| `enableVideo` | Set whether to join the meeting with your Camera ON (`true`) or OFF (`false`).                                                 |
+| `baseUrl`     | Base URL of the Dyte environment you have created the meeting on.                                                              |
 
 ```swift 
  let meetingInfo = DyteMeetingInfoV2(authToken: "<authToken>",


### PR DESCRIPTION
## Description

The Android quickstart docs had an empty, incorrect table column that broke Markdown rendering.

Current prod deployment at https://docs.dyte.io/android: 
<img width="967" alt="image" src="https://github.com/dyte-io/docs/assets/122249239/513e7a5c-b887-44af-9d45-9f65b46b4af7">

With this PR:
<img width="985" alt="image" src="https://github.com/dyte-io/docs/assets/122249239/385ce855-9fd5-436e-abb5-4bd82764db38">


## Resolved issues

N/A

### Before submitting the PR, please take the following into consideration
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. If you don't have an issue, please create one.
- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
- [x] The description should clearly illustrate what problems it solves.
- [x] Ensure that the commit messages follow our guidelines.
- [ ] Resolve merge conflicts (if any).
- [x] Make sure that the current branch is upto date with the `main` branch.
