### PR TITLE
docs: added bg perms for ios

### DIFF
--- a/docs/flutter-core/quickstart.mdx
+++ b/docs/flutter-core/quickstart.mdx
@@ -96,6 +96,15 @@ platform :ios, '13.0'
 
 <key>NSPhotoLibraryUsageDescription</key>
 <string>For people to share, we need access to your photos.</string>
+
+<key>UIBackgroundModes</key>
+<array>
+	<string>audio</string>
+	<string>voip</string>
+	<string>fetch</string>
+	<string>remote-notification</string>
+</array>
+
 ```
 
 In iOS, if you are allowing user to download attachments in chat, add the following permissions in your app's Info.plist:

--- a/docs/flutter/quickstart.mdx
+++ b/docs/flutter/quickstart.mdx
@@ -99,6 +99,15 @@ platform :ios, '13.0'
 
 <key>NSPhotoLibraryUsageDescription</key>
 <string>For people to share, we need access to your photos.</string>
+
+
+<key>UIBackgroundModes</key>
+<array>
+	<string>audio</string>
+	<string>voip</string>
+	<string>fetch</string>
+	<string>remote-notification</string>
+</array>
 ```
 
 3. In iOS, if you are allowing user to download attachments in chat, add the following permissions in your app's Info.plist:


### PR DESCRIPTION
Add background permissions info for Flutter Core and UI Kit.