### PR TITLE
fix: minor typo in guides/concepts

### DIFF
--- a/docs/guides/live-video/concepts.mdx
+++ b/docs/guides/live-video/concepts.mdx
@@ -78,7 +78,7 @@ To create a preset, please refer to our Developer Portal's [Presets Section](htt
 
 Now that you are familiar with the terminology of basic concepts on Dyte, we can take a look at how different parts of the Dyte system come together. The components are the REST API, core SDK , UIKit and a Developer Portal. Each of these serve different purposes and belong in different blocks of your application.
 
-Let's dive deeper into what purpose each of these components server.
+Let's dive deeper into what purpose each of these components serve.
 
 ### Developer Portal
 

--- a/docs/guides/voice-conf/concepts.mdx
+++ b/docs/guides/voice-conf/concepts.mdx
@@ -78,7 +78,7 @@ To create a preset, please refer to our Developer Portal's [Presets Section](htt
 
 Now that you are familiar with the terminology of basic concepts on Dyte, we can take a look at how different offerings from Dyte come together. The key offerings are the REST API, core SDK , UIKit and a Developer Portal. Each of these serve different purposes and belong in different blocks of your application.
 
-Let's dive deeper into what purpose each of these components server.
+Let's dive deeper into what purpose each of these components serve.
 
 ### Developer Portal
 


### PR DESCRIPTION
## Description

Describe your PR here.
In [this](https://docs.dyte.io/guides/live-video/concepts) doc, under `Components`, the last line currently says:
`Let's dive deeper into what purpose each of these components _server_.`
it should be:
`Let's dive deeper into what purpose each of these components _serve_.`


### Before submitting the PR, please take the following into consideration

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. If you don't have an issue, please create one.
- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
- [x] The description should clearly illustrate what problems it solves.
- [x] Ensure that the commit messages follow our guidelines.
- [ ] Resolve merge conflicts (if any).
- [ ] Make sure that the current branch is upto date with the `main` branch.
