### PR TITLE
docs(cli-auth): added programmatic auth command for Dyte CLI

### DIFF
--- a/docs/cli/getting-started.mdx
+++ b/docs/cli/getting-started.mdx
@@ -11,7 +11,7 @@ The Dyte CLI needs a little bit of work to get started. We're working on
 reducing the amount of effort required, but for now you'll have to do the
 following.
 
-## Configuration
+## Manual Configuration
 
 1. Authorize yourself with the Dyte Dev Portal. This allows you to access all
    the organizations that you belong to from the CLI.
@@ -26,13 +26,17 @@ dyte auth login
 dyte auth org
 ```
 
-Alternatively, you can programmatically authorize the Dyte CLI using the following command:
+## Programmatic Configuration
+
+If browser-based authorization via `dyte auth login` is not suitable, you can alternatively authorize the Dyte CLI programmatically using the following command:
 
 ```bash
 dyte config creds --org-id YOUR_DYTE_ORG_ID --api-key API_KEY_OF_THE_ORG
 ```
 
-This approach is particularly useful when integrating CI/CD pipelines into your custom plugin development workflow.
+This method is especially beneficial for automating workflows, such as integrating CI/CD pipelines in custom plugin development.
+
+Note that this is an organization-specific authorization. As a result, commands like dyte auth org will not function. However, you can still perform organization-specific operations, including publishing plugins and creating meetings.
 
 ## Usage
 

--- a/docs/cli/getting-started.mdx
+++ b/docs/cli/getting-started.mdx
@@ -26,6 +26,14 @@ dyte auth login
 dyte auth org
 ```
 
+Alternatively, you can programmatically authorize the Dyte CLI using the following command:
+
+```bash
+dyte config creds --org-id YOUR_DYTE_ORG_ID --api-key API_KEY_OF_THE_ORG
+```
+
+This approach is particularly useful when integrating CI/CD pipelines into your custom plugin development workflow.
+
 ## Usage
 
 ### General


### PR DESCRIPTION
## Use Case
A lot of end users have recently reported issues with not being able to programmatically release their plugins using CI/CD. Even though we have the ability to do so, it was not documented. I have documented it now.

## Steps to Test:
1. Go to https://0d307829.dyte-docs.pages.dev/cli.
2. Follow the steps to install the CLI tool.
3. There should be a programmatic configuration section in https://0d307829.dyte-docs.pages.dev/cli/getting-started with steps to authorize plugin development programmatically.
4. try creating and publishing a new plugin using just this without running `dyte auth login` at all.